### PR TITLE
Allow hiding handlers

### DIFF
--- a/OpenRastaSwagger.Test.Functional/OpenRastaSwagger.Test.Functional.csproj
+++ b/OpenRastaSwagger.Test.Functional/OpenRastaSwagger.Test.Functional.csproj
@@ -64,6 +64,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/OpenRastaSwagger.Test.Unit/Discovery/ResourceMetadataDiscovererFixture.cs
+++ b/OpenRastaSwagger.Test.Unit/Discovery/ResourceMetadataDiscovererFixture.cs
@@ -3,7 +3,6 @@ using System.Reflection;
 using NUnit.Framework;
 using OpenRasta.Configuration.MetaModel;
 using OpenRasta.TypeSystem.ReflectionBased;
-using OpenRasta.TypeSystem.Surrogated;
 using OpenRasta.Web;
 using OpenRastaSwagger.Discovery;
 using OpenRastaSwagger.DocumentationSupport;
@@ -147,10 +146,30 @@ namespace OpenRastaSwagger.Test.Unit.Discovery
             Assert.That(metadata[0].Group.Path, Is.EqualTo("test-with-attributes"));
         }
 
+        [Test]
+        public void HandlerWithObsoleteMethod_DoesNotRecogniseAsAHandler()
+        {
+            _model.Handlers.Clear();
+            _model.Handlers.Add(new HandlerModel(new ReflectionBasedType(new ReflectionBasedTypeSystem(), typeof(TestHandlerWithObsoleteAttribute))));
+
+            var metadata = _discoverer.Discover(_model);
+
+            Assert.That(metadata, Is.Empty);
+        }
+
         public class TestHandler { public OperationResult GetInt(int i) { return null; } public int GetInt2(int i) { return 0; } }
         public class TestHandlerWithAttribute { public OperationResult GetInt(int i) { return null; } [ResponseTypeIs(typeof(int))] public OperationResult GetInt2(int i) { return new OperationResult.OK(0); } }
         public abstract class TestHandlerWithProperyThatShouldNotBeDiscovered { public string Something { get; set; } }
         public class TestHandlerDerivedFromAbstract : TestHandlerWithProperyThatShouldNotBeDiscovered { }
+
+        public class TestHandlerWithObsoleteAttribute
+        {
+            [Obsolete]
+            public OperationResult GetInt(int i)
+            {
+                return null;
+            }
+        }
 
         public class FakeDiscoveryHeuristic : IDiscoveryHeuristic
         {

--- a/OpenRastaSwagger.Test.Unit/OpenRastaSwagger.Test.Unit.csproj
+++ b/OpenRastaSwagger.Test.Unit/OpenRastaSwagger.Test.Unit.csproj
@@ -77,6 +77,9 @@
       <Name>OpenRastaSwagger</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/OpenRastaSwagger/Discovery/ResourceMetadataDiscoverer.cs
+++ b/OpenRastaSwagger/Discovery/ResourceMetadataDiscoverer.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using OpenRasta.Configuration.MetaModel;
 using OpenRasta.TypeSystem;
-using OpenRasta.TypeSystem.ReflectionBased;
 using OpenRastaSwagger.Discovery.Heuristics;
 using OpenRastaSwagger.Grouping;
 
@@ -48,7 +48,11 @@ namespace OpenRastaSwagger.Discovery
             foreach (var uri in metadata.Uris)
             {
                 var candidateMethods = handler.Type.StaticType.GetMethods()
-                    .Where(x => x.IsPublic && !exclusions.Contains(x.Name) && !x.IsSpecialName);
+                    .Where(x => x.IsPublic)
+                    .Where(x => !exclusions.Contains(x.Name))
+                    .Where(x => !x.IsSpecialName)
+                    .Where(x => !IsMethodObsolete(x))
+                    .ToList();
 
                 foreach (var publicMethod in candidateMethods)
                 {
@@ -61,6 +65,11 @@ namespace OpenRastaSwagger.Discovery
                     }
                 }
             }
+        }
+
+        private static bool IsMethodObsolete(MethodInfo method)
+        {
+            return method.GetCustomAttribute<ObsoleteAttribute>() != null;
         }
     }
 }


### PR DESCRIPTION
Allow use of the `[Obsolete]` attribute on handlers to hide them from Swagger documents.